### PR TITLE
[Feature]  Add migrations for vehicles, brands and models tables

### DIFF
--- a/database/migrations/2024_11_19_172702_add_table_brands.php
+++ b/database/migrations/2024_11_19_172702_add_table_brands.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('brands', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 150);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('brands');
+    }
+};

--- a/database/migrations/2024_11_19_172805_add_table_models.php
+++ b/database/migrations/2024_11_19_172805_add_table_models.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('models', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 150);
+            $table->foreignId('brand_id')->constrained('brands');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('models');
+    }
+};

--- a/database/migrations/2024_11_19_173346_add_table_vehicles.php
+++ b/database/migrations/2024_11_19_173346_add_table_vehicles.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vehicles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('customer_id')->constrained('customers');
+            $table->foreignId('model_id')->constrained('models');
+            $table->string('license_plate', 20);
+            $table->string('year', 10);
+            $table->string('color', 100);
+            $table->string('vin', 100)->nullable();
+            $table->string('mileage', 50)->nullable();
+            $table->foreignId('user_who_created_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('user_who_updated_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('user_who_deleted_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vehicles');
+    }
+};


### PR DESCRIPTION
Contexto
Este PR agrega las tablas necesarias para gestionar vehiculos y sus marcas y sus modelos en la base de datos, como se describe en la issue #10 

Issue relacionada:
Closes #10 